### PR TITLE
Revert "脆弱性対応を取り込むためguavaのバージョンアップ (#39)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1-jre</version>
+      <version>18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This reverts commit 21570fb5c4e4fadd8351b5994b7252d9c760c0a3.

以下の理由により、guavaのバージョンアップ対応を差し戻すことになった。

- そもそも、 guava を使っているのは test スコープなので、脆弱性の影響は無い
- guava のバージョンを上げることにより Java 8 以上でしかテストの実行ができなくなる
  - リリースパイプラインでは Java 7 でのテストを実行しており、これを修正すると動作確認を取っているバージョンが変わることになり、ガイドなどにも影響が波及する可能性がある（リリース時期が迫っており、対応が厳しい）