### PR TITLE
guavaのバージョンを戻す修正をdevelopから取り込み

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>24.1.1-jre</version>
+      <version>18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
[こちらのPR](https://github.com/nablarch/nablarch-etl/pull/43)を develop からリリースブランチ(release-5u19)に取り込むPRです。